### PR TITLE
Include digit 9 while parsing ISO8601 recurrence

### DIFF
--- a/base/src/main/java/net/time4j/range/IsoRecurrence.java
+++ b/base/src/main/java/net/time4j/range/IsoRecurrence.java
@@ -876,7 +876,7 @@ public class IsoRecurrence<I>
                 total = 0;
             }
             int digit = (parts[0].charAt(i) - '0');
-            if (digit >= 0 && digit < 9) {
+            if (digit >= 0 && digit <= 9) {
                 total = total * 10 + digit;
             } else {
                 throw new ParseException("Digit 0-9 is missing.", i);

--- a/base/src/test/java/net/time4j/range/IsoRecurrenceTest.java
+++ b/base/src/test/java/net/time4j/range/IsoRecurrenceTest.java
@@ -341,11 +341,11 @@ public class IsoRecurrenceTest {
         assertThat(IsoRecurrence.parseTimestampIntervals("R87/2016-07-01T10:15:59/02T16:45:00.123"), is(expected));
         expected =
             IsoRecurrence.of(
-                2,
+                9,
                 PlainTimestamp.of(2016, 7, 1, 10, 15, 59),
                 PlainTimestamp.of(2016, 7, 1, 16, 45, 0).plus(123, ClockUnit.MILLIS));
-        assertThat(IsoRecurrence.parseTimestampIntervals("R2/2016-07-01T10:15:59/T16:45:00.123"), is(expected));
-        assertThat(IsoRecurrence.parseTimestampIntervals("R2/2016-07-01T10:15:59/16:45:00.123"), is(expected));
+        assertThat(IsoRecurrence.parseTimestampIntervals("R9/2016-07-01T10:15:59/T16:45:00.123"), is(expected));
+        assertThat(IsoRecurrence.parseTimestampIntervals("R9/2016-07-01T10:15:59/16:45:00.123"), is(expected));
     }
 
     @Test


### PR DESCRIPTION
I believe there is a typo that prevents parsing recurrence with `9` in it.