### PR TITLE
Updated Danish eras naming.

### DIFF
--- a/base/src/main/resources/names/iso8601/iso8601_da.properties
+++ b/base/src/main/resources/names/iso8601/iso8601_da.properties
@@ -237,19 +237,19 @@ P(W)_night1=nat
 
 # eras
 E(w)_0=f.Kr.
-E(w|alt)_0=før vesterlandsk tidsregning
+E(w|alt)_0=før vor tidsregning
 E(w)_1=e.Kr.
-E(w|alt)_1=vesterlandsk tidsregning
+E(w|alt)_1=efter vor tidsregning
 
 E(a)_0=f.Kr.
 E(a|alt)_0=f.v.t.
 E(a)_1=e.Kr.
-E(a|alt)_1=v.t.
+E(a|alt)_1=e.v.t.
 
 E(n)_0=fKr
 E(n|alt)_0=fvt
 E(n)_1=eKr
-E(n|alt)_1=vt
+E(n|alt)_1=evt
 
 # format patterns
 F(f)_d=EEEE 'den' d. MMMM y


### PR DESCRIPTION
I have fixed some translations to a more correct Danish inside iso8601_da.properties.